### PR TITLE
Rename qabro to bugit

### DIFF
--- a/pmr.conf
+++ b/pmr.conf
@@ -37,7 +37,7 @@
 [lp:revcache]
 [lp:can-echo-server]
 [lp:checkbox-provider-mcp2210]
-[lp:qabro]
+[lp:bugit]
 [lp:checkbox-provider-tools]
 [lp:checkbox-provider-phoronix]
 [lp:checkbox-provider-gpgpu]


### PR DESCRIPTION
The "qabro" project was renamed "bugit" and now lives in

https://launchpad.net/bugit

with all the URLs updated accordingly.